### PR TITLE
Removed space from enum name

### DIFF
--- a/library/src/main/res/values/attrs_maskable_framelayout.xml
+++ b/library/src/main/res/values/attrs_maskable_framelayout.xml
@@ -5,7 +5,7 @@
         <attr name="porterduffxfermode">
             <enum name="ADD" value="0"/>
             <enum name="CLEAR" value="1"/>
-            <enum name="DARKEN " value="2"/>
+            <enum name="DARKEN" value="2"/>
             <enum name="DST" value="3"/>
             <enum name="DST_ATOP" value="4"/>
             <enum name="DST_IN" value="5"/>


### PR DESCRIPTION
Space in enum name causing issues compiling projects.

Ex.
https://stackoverflow.com/questions/47337128/error-is-not-a-valid-resource-name-character-after-updating-to-android-gr/47348843#47348843