### PR TITLE
Update from getInteger to getInt

### DIFF
--- a/library/src/main/java/com/christophesmet/android/views/maskableframelayout/MaskableFrameLayout.java
+++ b/library/src/main/java/com/christophesmet/android/views/maskableframelayout/MaskableFrameLayout.java
@@ -95,7 +95,7 @@ public class MaskableFrameLayout extends FrameLayout {
                 initMask(loadMask(a));
                 //Load the mode if specified in xml
                 mPorterDuffXferMode = getModeFromInteger(
-                        a.getInteger(R.styleable.MaskableLayout_porterduffxfermode, 0));
+                        a.getInt(R.styleable.MaskableLayout_porterduffxfermode, 0));
                 initMask(mDrawableMask);
                 //Check antiAlias
                 if (a.getBoolean(R.styleable.MaskableLayout_anti_aliasing, false)) {


### PR DESCRIPTION
Updated `TypedArray.getInteger` to `TypedArray.getInt` get `porterduffxfermode`

I don't know if this is experienced by someone but, in my end i'm able to experience a crash in my app because the library throws an `UnsupportedOperationException`

> Caused by: java.lang.UnsupportedOperationException: Can't convert value at index 1 to integer: type=0x3

