### PR TITLE
Added option to define width and height of mask

### DIFF
--- a/library/src/main/java/com/christophesmet/android/views/maskableframelayout/MaskableFrameLayout.java
+++ b/library/src/main/java/com/christophesmet/android/views/maskableframelayout/MaskableFrameLayout.java
@@ -63,6 +63,9 @@ public class MaskableFrameLayout extends FrameLayout {
     private Paint mPaint = null;
     private PorterDuffXfermode mPorterDuffXferMode = null;
 
+    private int maskWidth;
+    private int maskHeight;
+
     public MaskableFrameLayout(Context context) {
         super(context);
     }
@@ -103,12 +106,15 @@ public class MaskableFrameLayout extends FrameLayout {
                     //This can take a performance hit.
                     mPaint = createPaint(true);
                 }
+                maskWidth = a.getDimensionPixelSize(R.styleable.MaskableLayout_maskWidth, -1);
+                maskHeight = a.getDimensionPixelSize(R.styleable.MaskableLayout_maskHeight, -1);
             } finally {
                 if (a != null) {
                     a.recycle();
                 }
             }
-        } else {
+        }
+        else {
             log("Couldn't load theme, mask in xml won't be loaded.");
         }
         registerMeasure();
@@ -151,7 +157,10 @@ public class MaskableFrameLayout extends FrameLayout {
                 Bitmap mask = Bitmap.createBitmap(getMeasuredWidth(), getMeasuredHeight(),
                         Bitmap.Config.ARGB_8888);
                 Canvas canvas = new Canvas(mask);
-                drawable.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                if (maskWidth == -1 || maskHeight == -1)
+                    drawable.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                else
+                    setCustomBoundsToDrawable(drawable);
                 drawable.draw(canvas);
                 return mask;
             } else {
@@ -162,6 +171,11 @@ public class MaskableFrameLayout extends FrameLayout {
             log("No bitmap mask loaded, view will NOT be masked !");
         }
         return null;
+    }
+
+    private void setCustomBoundsToDrawable(Drawable d) {
+        d.setBounds((getMeasuredWidth()/2)-(maskWidth/2),(getMeasuredHeight()/2)-(maskHeight/2),(getMeasuredWidth()/2)-(maskWidth/2)+maskWidth,(getMeasuredHeight()/2)-
+                (maskHeight/2)+maskHeight);
     }
 
     public void setMask(int drawableRes) {

--- a/library/src/main/res/values/attrs_maskable_framelayout.xml
+++ b/library/src/main/res/values/attrs_maskable_framelayout.xml
@@ -23,5 +23,7 @@
             <enum name="XOR" value="17"/>
         </attr>
         <attr name="anti_aliasing" format="boolean"/>
+        <attr name="maskWidth" format="dimension"/>
+        <attr name="maskHeight" format="dimension"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
- added two attributes (width and height) to maskable layout
- in case of custom dimensions, mask is aligned to center
- in case of no attributes, match parent is used