### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Or use JitPack: https://jitpack.io/#christophesmet/android_maskable_layout
 repositories {
     maven { url 'https://jitpack.io' }
 }
-    compile 'com.github.christophesmet:android_maskable_layout:v1.2.0'
+    implementation 'com.github.christophesmet:android_maskable_layout:v1.2.0'
 ```
 
 License


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.